### PR TITLE
[Feature] Add Graceful Shutdown Mechanism and Fallback Subscription Support for MQTT Client

### DIFF
--- a/examples/testclient.py
+++ b/examples/testclient.py
@@ -37,9 +37,19 @@ def handle_weather3(topic: str, msg: mqroute.MQTTMessage, _: dict[str, Any]):
     logger.info(f"         3 topic: {topic}")
     logger.info(f"         3 {payload_type}: {msg.message}")
 
+@mqtt.sigstop
+def sigstop_handler():
+    logger.info("sigstop_handler called !!!!")
+
+
+async def main():
+    await mqtt.run()
+
+    # Keep the client running
+    while mqtt.running:
+        await asyncio.sleep(0.1)
 
 
 if __name__ == "__main__":
     basicConfig(level=DEBUG)
-    asyncio.run(mqtt.run())
-
+    asyncio.run(main())

--- a/examples/testclient.py
+++ b/examples/testclient.py
@@ -27,7 +27,10 @@ async def handle_weather2(topic: str, msg: mqroute.MQTTMessage, parameters: dict
     logger.info(f"         2 parameters: {parameters}")
     logger.info(f"         2 {payload_type}: {msg.message}")
 
-@mqtt.subscribe(topic="weather/#", qos=mqroute.QOS.EXACTLY_ONCE, raw_payload=True)
+@mqtt.subscribe(topic="weather/#",
+                qos=mqroute.QOS.EXACTLY_ONCE,
+                raw_payload=True,
+                fallback=True)
 def handle_weather3(topic: str, msg: mqroute.MQTTMessage, _: dict[str, Any]):
     payload_type = type(msg.message).__name__
     logger.info("message:  (handle_weather3)")

--- a/mqroute/mqtt_client.py
+++ b/mqroute/mqtt_client.py
@@ -81,7 +81,8 @@ class MQTTClient(object):
     def subscribe(self,
                   topic: str,
                   qos: QOS = QOS.AT_MOST_ONCE,
-                  raw_payload: bool = False):
+                  raw_payload: bool = False,
+                  fallback: bool = False):
         """
         The `subscribe` method facilitates MQTT topic subscription by allowing the user to create
         a decorator that processes incoming messages before invoking the decorated function.
@@ -102,6 +103,8 @@ class MQTTClient(object):
         :param qos: The Quality of Service level for the topic subscription.
         :param raw_payload: If set to True, the message payload will not be converted from JSON.
                             Defaults to False.
+        :param fallback: If set to True, the callback is only called when no other callbacks were called by
+                            the topic. Defaults to False.
         :return: A decorator function that wraps the user's callback function.
         """
         def decorator(func):
@@ -119,7 +122,8 @@ class MQTTClient(object):
 
             rewritten_topic = self.__msg_callbacks.register(topic=topic,
                                                             callback=wrapper,
-                                                            payload_format=payload_format)
+                                                            payload_format=payload_format,
+                                                            fallback=fallback)
             self.subscribe_topic(rewritten_topic, qos)
 
             return wrapper

--- a/mqroute/topic_node.py
+++ b/mqroute/topic_node.py
@@ -52,14 +52,16 @@ class TopicNode(object):
     part: Optional[str]
     parameter: Optional[str] = None
     callback: Callable[[str, MQTTMessage, Optional[dict[str, str]]], None] = None
-    payload_format: Enum = None
+    payload_format: Optional[Enum] = None
+    fallback: Optional[bool] = None
     nodes: dict[str, "TopicNode"] = field(default_factory=dict)
 
 
     def register(self,
                  parts: list[str],
                  callback_method: Callable[[str, MQTTMessage, Optional[dict[str, str]]], None],
-                 payload_format: Enum):
+                 payload_format: Enum,
+                 fallback: bool = False):
         """
         Registers a callback method for a specific topic structure within a tree-like topic
         hierarchy. The method can handle both generic topics represented by "+", special topics
@@ -75,7 +77,11 @@ class TopicNode(object):
             object of type MQTTMessage, and an optional dictionary of parameters (if present)
             extracted from the topic.
         :type callback_method: Callable[[str, MQTTMessage, Optional[dict[str, str]]], None]
-        :return: None
+        ivar payload_format: Expected payload format for payload (default is JSON).
+            The type is any Enum type in order to allow customization of supported payload formats.
+        :type payload_format: Enum
+        :ivar fallback: If True, the callback will be matched only if no other matches are found
+        :type payload_format: bool:return: None
         :rtype: None
         """
         part = parts[0]
@@ -97,8 +103,9 @@ class TopicNode(object):
         if len(parts) == 1:
             node.callback = callback_method
             node.payload_format = payload_format
+            node.fallback = fallback
         else:
-            node.register(parts[1:], callback_method, payload_format)
+            node.register(parts[1:], callback_method, payload_format, fallback)
 
 
     def __check_topic(self, parts: list[str]):


### PR DESCRIPTION
- **Graceful Shutdown**:
    - Implemented `sigstop_handler` for handling termination signals (e.g., `SIGSTOP`, `SIGTERM`, `SIGINT`) and added a `sigstop` decorator to enable user-defined custom shutdown routines.
    - Introduced a `stop` method to safely halt the client's message loop and callback processing, releasing resources and shutting down the internal queue in the callback runner gracefully.
    - Improved runtime behavior by managing the client's continuous execution with `async` methods to ensure smoother operation and better integration with event loops.

- **Fallback Subscription Support**:
    - Added a `fallback` parameter to subscriptions, allowing alternate callbacks to be executed when no other non fallback topic matches are found.
    - Updated the callback resolver and topic node handling to accommodate fallback callbacks, ensuring greater flexibility and resilience in message processing.
