### PR TITLE
Add dynamic MQTT subscription method via functional interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,15 @@ async def sigstop_handler():
     # termination requested
     print(f"Received request to terminate application.")
 
+    
+async def handle_green_light_status(topic, msg, params):
+    print(f"Green sensor status: {msg.message}")
 
 
 async def main():
+    # callback can also be added using functional interface.
+    mqtt.add_subscription(handle_green_light_status,
+                          topic="sensors/green/status")
     await mqtt.run()
 
     # Keep the client running
@@ -188,8 +194,8 @@ pytest tests/
 
 - **Message Publishing API:** Simple methods for publishing MQTT messages.
 - **Customization and extendability:** Allow easy means  to support for example custom payload formats
-- **Dynamic subscriptions:** Subscribe MQTT topics without decorators in order to allow dynamic
-   construction of mqroute application.
+- **Demo environment**: Demo environment with mqtt router and two mqroute clients talking. This would allow
+                        demo client to not depend on test.mosquitto.org
 ---
 
 ## **Contributing**

--- a/examples/testclient.py
+++ b/examples/testclient.py
@@ -56,15 +56,33 @@ def handle_weather3(topic: str, msg: mqroute.MQTTMessage, _: dict[str, Any]):
     logger.info("         3 topic:%s", topic)
     logger.info("         3 %s: %s", payload_type, msg.message)
 
-
 @mqtt.sigstop
 def sigstop_handler():
     """ Simple example of custom SIGSTOP handler callback."""
     logger.info("sigstop_handler called !!!!")
 
 
+async def handle_weather4(topic: str, msg: mqroute.MQTTMessage, _: dict[str, Any]):
+    """ Simple example method processing received MQTT messages that have matching topic
+     and are not processed by any other callback."""
+    payload_type = type(msg.message).__name__
+    logger.info("message:  (handle_weather4)")
+    logger.info("         4 topic:%s", topic)
+    logger.info("         4 %s: %s", payload_type, msg.message)
+
+
 async def main():
-    """ Exxample implementation of main running mqroute instance."""
+    """ Example implementation of main running mqroute instance."""
+
+    # register one of the handlers using functional interface (allows dynamic creation of
+    # subscriptions)
+    mqtt.add_subscription(handle_weather4,
+                          topic="weather/vt-dev/wflwflexpj.json",
+                          qos=mqroute.QOS.EXACTLY_ONCE,
+                          raw_payload=False,
+                          fallback=False)
+
+    # start mqroute client
     await mqtt.run()
 
     # Keep the client running

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mqroute"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   { name="ehyde74" },
 ]
@@ -12,7 +12,7 @@ description = "MQRoute is a Python library designed to simplify working with MQT
 readme = {file = "README.md", content-type = "text/markdown"}
 keywords = ["mqtt", "asyncio", "decorators"]
 license = {text = "MIT License"}
-requires-python = ">=3.8"
+requires-python = ">=3.13"
 dependencies = [
   "paho-mqtt>=2.1.0",
   "typeguard>=4.4.1",


### PR DESCRIPTION
Introduced `add_subscription` for dynamic topic subscriptions, allowing users to bind callbacks to MQTT topics at runtime using a functional approach. Also updated Python version requirement to 3.13 and incremented the project version to 0.2.2.